### PR TITLE
Fixing select performance

### DIFF
--- a/src/js/jquery.form.generator.js
+++ b/src/js/jquery.form.generator.js
@@ -380,7 +380,6 @@
                         var option = $("<option/>");
                         option.attr('value', value);
                         option.html(title);
-                        option.data(this);
                         select.append(option);
                     });
                 }


### PR DESCRIPTION
Inside the `_.each` `this` is not bound to anything else than the window object. Storing it with `.data()` causes serious performance drops in case of larger selects.