### PR TITLE
Add querystring parameter to generated href for tab a-Elements

### DIFF
--- a/src/js/elements/tab.navigator.js
+++ b/src/js/elements/tab.navigator.js
@@ -79,7 +79,9 @@
             var navigation = $("> .ui-tabs-nav",el);
             var id = item.hasOwnProperty('id') ? item.id : 'tabs-' + guid();
             //location.href alone will not work with html-base-tag in some cases, so we use this monstrosity here to be 100% safe
-            var href = location.origin + location.pathname + /\?.*/.exec(location.href)[0] +'#'+id;
+            var queryStringMatch = /\?.*/.exec(location.href);
+            var queryString = queryStringMatch && queryStringMatch[0] || '';
+            var href = location.origin + location.pathname + queryString +'#'+id;
             var label = $('<li><a role="tab" data-toggle="tab" href="' + href+ '">' + item.title + (this.isClosable() ? '<span class="close">Close</span>' : '') + '</a></li>');
             var contentHolder = $("<div id='" + id + "' class='tab-content'/>");
 

--- a/src/js/elements/tab.navigator.js
+++ b/src/js/elements/tab.navigator.js
@@ -78,7 +78,8 @@
             var el = this.element;
             var navigation = $("> .ui-tabs-nav",el);
             var id = item.hasOwnProperty('id') ? item.id : 'tabs-' + guid();
-            var href = location.origin + location.pathname+'#'+id;
+            //location.href alone will not work with html-base-tag in some cases, so we use this monstrosity here to be 100% safe
+            var href = location.origin + location.pathname + /\?.*/.exec(location.href)[0] +'#'+id;
             var label = $('<li><a role="tab" data-toggle="tab" href="' + href+ '">' + item.title + (this.isClosable() ? '<span class="close">Close</span>' : '') + '</a></li>');
             var contentHolder = $("<div id='" + id + "' class='tab-content'/>");
 


### PR DESCRIPTION
Otherwise there are some edge-cases which will generate missmatching uris to the site uri and jQuery-UI will interprete these a remote and render a new page instead of the tab.