### PR TITLE
enable tabloading functionality even when second dialog is still in t…

### DIFF
--- a/src/js/utils/fn.formData.js
+++ b/src/js/utils/fn.formData.js
@@ -165,7 +165,7 @@ $.fn.formData = (function() {
             var isValid = VisUi.validateInput(input);
             if (!isValid && !firstInput) {
                 var $tabElement = input.closest('.ui-tabs');
-                var tabIndex = $tabElement.length && input.closest('.ui-tabs-panel').index('.ui-tabs-panel');
+                var tabIndex = $tabElement.length && $tabElement.find(".ui-tabs-panel").index($panelElement);
                 if ($tabElement) {
                     $tabElement.tabs({active: tabIndex});
                 }


### PR DESCRIPTION
Warning tab did not show up when there was a second dialog open, i.e. closed but still in the DOM. 